### PR TITLE
Parse multiple docs

### DIFF
--- a/lib/osm2json.js
+++ b/lib/osm2json.js
@@ -37,7 +37,7 @@ var WHITELISTS = {
   },
   changeset: {
     attributes: ['id', 'user', 'uid', 'created_at', 'closed_at', 'open',
-        'min_lat', 'min_lon', 'max_lat', 'max_lon', 'comments_count'],
+      'min_lat', 'min_lon', 'max_lat', 'max_lon', 'comments_count'],
     children: ['tag']
   },
   bounds: {

--- a/lib/osm2json.js
+++ b/lib/osm2json.js
@@ -94,6 +94,9 @@ function Osm2Json (opts) {
   this.parser.onopentag = this.onOpenTag.bind(this)
   this.parser.onclosetag = this.onCloseTag.bind(this)
   Transform.call(this, { readableObjectMode: true })
+
+  // seed the parser so it can handle multiple roots
+  this.parser.write('<root>')
 }
 
 util.inherits(Osm2Json, Transform)

--- a/test/test.js
+++ b/test/test.js
@@ -116,3 +116,22 @@ test('osmChange with delete if-unused', function (t) {
     t.end()
   }))
 })
+
+test('multiple documents', function (t) {
+  var expected = require('./output_osmChange.json').concat([
+    { action: 'delete', changeset: 42, id: 12, lat: 1, lon: 2, type: 'node', version: 1, ifUnused: true },
+    { action: 'delete', changeset: 42, id: 34, lat: 3, lon: 4, type: 'node', version: 1 }
+  ])
+  var parser = new Osm2Json()
+  var rs1 = fs.readFileSync(path.join(__dirname, 'osmChange.xml'))
+  var rs2 = fs.readFileSync(path.join(__dirname, 'osmChange_ifunused.xml'))
+
+  parser.pipe(concat(function (data) {
+    t.deepEqual(data, expected)
+    t.end()
+  }))
+
+  parser.write(rs1)
+  parser.write(rs2)
+  parser.end()
+})


### PR DESCRIPTION
This seeds the XML parser so that it can happily handle multiple docs (or multiple fully closed inputs), e.g. repeated `<OsmChange />` fragments.