### PR TITLE
Add support for empty tags

### DIFF
--- a/lib/osm2json.js
+++ b/lib/osm2json.js
@@ -173,7 +173,7 @@ Osm2Json.prototype.processChild = function (node) {
   var attr = node.attributes
   switch (node.name) {
     case 'tag':
-      if (!attr.k || !attr.v) {
+      if (!attr.k || attr.v == null) {
         return this.onError(new Error('<tag> missing k or v attribute'))
       }
       currentNode.tags = currentNode.tags || {}

--- a/test/osm.xml
+++ b/test/osm.xml
@@ -34,5 +34,6 @@
     <member type="node" ref="19" role=""/>
     <member type="way" ref="3" role="outer"/>
     <tag k="test" v="relation"/>
+    <tag k="empty" v="" />
   </relation>
 </osm>

--- a/test/output_defaults.json
+++ b/test/output_defaults.json
@@ -144,7 +144,8 @@
       }
     ],
     "tags": {
-      "test": "relation"
+      "test": "relation",
+      "empty": ""
     },
     "timestamp": "2013-09-05T19:38:11Z",
     "version": 1

--- a/test/output_string_ids.json
+++ b/test/output_string_ids.json
@@ -144,7 +144,8 @@
       }
     ],
     "tags": {
-      "test": "relation"
+      "test": "relation",
+      "empty": ""
     },
     "timestamp": "2013-09-05T19:38:11Z",
     "version": "1"


### PR DESCRIPTION
Explicitly check for `null` rather than `false` to allow `""` as a valid tag value.