### PR TITLE
Ignore invalid tag and tolerate error

### DIFF
--- a/lib/osm2obj.js
+++ b/lib/osm2obj.js
@@ -174,10 +174,13 @@ Osm2Obj.prototype.processChild = function (node) {
   switch (node.name) {
     case 'tag':
       if (!attr.k || attr.v == null) {
-        return this.onError(new Error('<tag> missing k or v attribute'))
+        if (this.opts.strict) {
+          return this.onError(new Error('<tag> missing k or v attribute'))
+        }
+      } else {
+        currentNode.tags = currentNode.tags || {}
+        currentNode.tags[attr.k] = attr.v
       }
-      currentNode.tags = currentNode.tags || {}
-      currentNode.tags[attr.k] = attr.v
       break
     case 'nd':
       if (!attr.ref) {


### PR DESCRIPTION
Got error on processing osc file from http://download.geofabrik.de/asia/china-updates/000/001/641.osc.gz :

```
Error: Invalid XML at line #49414, column #27:
<tag> missing k or v attribute
```

It's caused by the empty key in line 49415 in the downloaded OSM change file.

``` xml
<node id="5104989386" version="1" timestamp="2017-09-14T10:25:02Z" uid="499500" user="hanchao" changeset="52032689" lat="38.9875205" lon="116.4903698">
      <tag k="" v="hotel"/>
      <tag k="name" v="文安鲁能华美达广场酒店"/>
</node>
```

In order to not break auto process flow, I would suggest osm2obj to tolerate source data error and just ignore invalid tag.